### PR TITLE
Use hashed/salted passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,13 @@ we've conformed naming of secrets in the three locations you'll find them, that 
 3. In the source code, populated from `process.env`
   (also defined as static strings as members of the `SECRET_NAMES` array defined in [`index.js`](functions/index.js))
 
-| Secret Name | Description |
-| ----------- | ----------- |
-| `ABLY_API_KEY_RIDERS` | Used to sign JSON web tokens returned to `rider` users by this service. |
-| `ABLY_API_KEY_CUSTOMERS` | Used to sign JSON web tokens returned to `customer` users by this service. |
-| `MAPBOX_ACCESS_TOKEN` | Returned to Rider apps in [Assign Order](#assign-order) responses. |
-| `GOOGLE_MAPS_API_KEY` | Returned to Customer apps in [Create Order](#create-order) responses. |
+| Secret Name              | Description                                                                                           |
+|--------------------------|-------------------------------------------------------------------------------------------------------|
+| `ABLY_API_KEY_RIDERS`    | Used to sign JSON web tokens returned to `rider` users by this service.                               |
+| `ABLY_API_KEY_CUSTOMERS` | Used to sign JSON web tokens returned to `customer` users by this service.                            |
+| `MAPBOX_ACCESS_TOKEN`    | Returned to Rider apps in [Assign Order](#assign-order) responses.                                    |
+| `GOOGLE_MAPS_API_KEY`    | Returned to Customer apps in [Create Order](#create-order) responses.                                 |
+| `INITIAL_USER_PASSWORD`  | Creates an initial `admin` user with this password, used for creating `rider` and `customer` accounts |
 
 ### Ably API Key Capabilities
 

--- a/firebase.json
+++ b/firebase.json
@@ -2,6 +2,18 @@
   "functions": {
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
-    ]
+    ],
+    "source": "functions"
+  },
+  "emulators": {
+    "functions": {
+      "port": 5001
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true
+    }
   }
 }

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.secret.local

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+# Firebase file for storing local secrets for development
 .secret.local

--- a/functions/Handlers.js
+++ b/functions/Handlers.js
@@ -13,7 +13,9 @@ const {
   STATUS_CODE_OK,
   ABLY_API_KEY_CUSTOMERS,
   ABLY_API_KEY_RIDERS,
+  isUserType,
 } = require('./common');
+const { createUserAccount } = require('./auth');
 
 class RequestError extends Error {
   constructor(message = 'Invalid request.', ...args) {
@@ -347,6 +349,16 @@ exports.getAbly = async (req, res, next) => {
     .send({
       token: webToken,
     });
+};
+
+exports.createUser = async (req, res) => {
+  const { username, password, type } = req.body;
+  if (!isUserType(type)) {
+    fail(res, STATUS_CODE_BAD_REQUEST, 'Invalid user type');
+    return;
+  }
+  await createUserAccount(username, password, type);
+  res.status(STATUS_CODE_CREATED).send({ username });
 };
 
 function assertNumber(value) {

--- a/functions/auth.js
+++ b/functions/auth.js
@@ -1,6 +1,6 @@
 const basicAuth = require('basic-auth');
 const crypto = require('crypto');
-const functions = require('firebase-functions');
+const { logger } = require('firebase-functions');
 const {
   fail,
   STATUS_CODE_UNAUTHORIZED,
@@ -9,8 +9,6 @@ const {
   USER_TYPE_ADMIN,
   INITIAL_USER_PASSWORD,
 } = require('./common');
-
-const { logger } = functions;
 
 module.exports.authorizeMiddleware = async (req, res, next) => {
   const credentials = basicAuth(req);

--- a/functions/auth.js
+++ b/functions/auth.js
@@ -1,0 +1,62 @@
+const basicAuth = require('basic-auth');
+const crypto = require('crypto');
+const functions = require('firebase-functions');
+const {
+  fail,
+  STATUS_CODE_UNAUTHORIZED,
+  firestore,
+  isUserType,
+} = require('./common');
+
+const { logger } = functions;
+
+module.exports.authorizeMiddleware = async (req, res, next) => {
+  const credentials = basicAuth(req);
+  if (!credentials) {
+    logger.info('Invalid Authorization header, or header missing.');
+    fail(res, STATUS_CODE_UNAUTHORIZED); // intentionally not providing a message as it could assist probing hackers
+    return;
+  }
+
+  const { name, pass } = credentials;
+
+  let data;
+  try {
+    const snapshot = await firestore.collection('users').doc(name).get();
+    data = snapshot.data();
+  } catch (error) {
+    // Ask Express to respond with HTTP 500 Internal Server Error.
+    // see: https://expressjs.com/en/guide/error-handling.html
+    // It's worth noting that, by default, Express serves this as HTML and includes all Error detail.
+    // It's also worth noting that this code was written against Express 4, given Express 5 was still in Beta - which
+    // explains why we need to do this error propagation 'by hand'.
+    next(error);
+    return;
+  }
+
+  if (!data) {
+    logger.info(`User '${name}' not found.`);
+  } else if (comparePassword(pass, data.password, data.salt)) {
+    const userType = data.type;
+    if (!isUserType(userType)) {
+      next(new Error(`User type '${userType}', as specified for user '${name}', is unknown.`));
+      return;
+    }
+
+    // make available for other middleware, specifically API handlers
+    res.locals.username = name;
+    res.locals.userType = userType;
+
+    next(); // Success
+    return;
+  }
+
+  logger.info(`Incorrect password supplied for user '${name}'. Received '${pass}', expected '${data.password}'.`);
+  fail(res, STATUS_CODE_UNAUTHORIZED); // intentionally not providing a message as it could assist probing hackers
+};
+
+// Compares the input password and salt to the stored SHA256 hash in the user data
+const comparePassword = (input, hashedPassword, salt) => {
+  const hashedInput = crypto.createHash('sha256').update(salt + input).digest('hex');
+  return hashedInput === hashedPassword;
+};

--- a/functions/auth.js
+++ b/functions/auth.js
@@ -51,7 +51,7 @@ module.exports.authorizeMiddleware = async (req, res, next) => {
     return;
   }
 
-  logger.info(`Incorrect password supplied for user '${name}'. Received '${pass}', expected '${data.password}'.`);
+  logger.info(`Incorrect password supplied for user '${name}'.`);
   fail(res, STATUS_CODE_UNAUTHORIZED); // intentionally not providing a message as it could assist probing hackers
 };
 

--- a/functions/common.js
+++ b/functions/common.js
@@ -20,7 +20,7 @@ exports.USER_TYPE_ADMIN = 'admin';
 exports.ABLY_API_KEY_RIDERS = 'ABLY_API_KEY_RIDERS';
 exports.ABLY_API_KEY_CUSTOMERS = 'ABLY_API_KEY_CUSTOMERS';
 
-exports.HASHING_SECRET = 'HASHING_SECRET';
+exports.INITIAL_USER_PASSWORD = 'INITIAL_USER_PASSWORD';
 
 exports.isUserType = (value) => {
   switch (value) {

--- a/functions/common.js
+++ b/functions/common.js
@@ -15,6 +15,7 @@ exports.STATUS_CODE_INTERNAL_SERVER_ERROR = 500;
 
 exports.USER_TYPE_CUSTOMER = 'customer';
 exports.USER_TYPE_RIDER = 'rider';
+exports.USER_TYPE_ADMIN = 'admin';
 
 exports.ABLY_API_KEY_RIDERS = 'ABLY_API_KEY_RIDERS';
 exports.ABLY_API_KEY_CUSTOMERS = 'ABLY_API_KEY_CUSTOMERS';
@@ -25,6 +26,7 @@ exports.isUserType = (value) => {
   switch (value) {
     case this.USER_TYPE_CUSTOMER:
     case this.USER_TYPE_RIDER:
+    case this.USER_TYPE_ADMIN:
       return true;
 
     default:

--- a/functions/common.js
+++ b/functions/common.js
@@ -19,6 +19,8 @@ exports.USER_TYPE_RIDER = 'rider';
 exports.ABLY_API_KEY_RIDERS = 'ABLY_API_KEY_RIDERS';
 exports.ABLY_API_KEY_CUSTOMERS = 'ABLY_API_KEY_CUSTOMERS';
 
+exports.HASHING_SECRET = 'HASHING_SECRET';
+
 exports.isUserType = (value) => {
   switch (value) {
     case this.USER_TYPE_CUSTOMER:

--- a/functions/index.js
+++ b/functions/index.js
@@ -52,7 +52,7 @@ const authorizeMiddleware = async (req, res, next) => {
     // see: https://expressjs.com/en/guide/error-handling.html
     // It's worth noting that, by default, Express serves this as HTML and includes all Error detail.
     // It's also worth noting that this code was written against Express 4, given Express 5 was still in Beta - which
-    // explains why we need to do this error propogation 'by hand'.
+    // explains why we need to do this error propagation 'by hand'.
     next(error);
     return;
   }

--- a/functions/index.js
+++ b/functions/index.js
@@ -9,8 +9,8 @@ const {
   STATUS_CODE_INTERNAL_SERVER_ERROR,
   ABLY_API_KEY_CUSTOMERS,
   ABLY_API_KEY_RIDERS,
-  HASHING_SECRET,
   USER_TYPE_ADMIN,
+  INITIAL_USER_PASSWORD,
 } = require('./common');
 
 const {
@@ -24,6 +24,7 @@ const {
 } = require('./Handlers');
 
 const {
+  createInitialUser,
   authorizeMiddleware,
   userIsOfTypeMiddleware,
 } = require('./auth');
@@ -31,7 +32,7 @@ const {
 const SECRET_NAMES = [
   ABLY_API_KEY_RIDERS,
   ABLY_API_KEY_CUSTOMERS,
-  HASHING_SECRET,
+  INITIAL_USER_PASSWORD,
   'MAPBOX_ACCESS_TOKEN',
   'GOOGLE_MAPS_API_KEY',
 ];
@@ -45,6 +46,9 @@ const errorHandlingMiddleware = (err, req, res, next) => {
   }
   fail(res, STATUS_CODE_INTERNAL_SERVER_ERROR, err.message);
 };
+
+// Create the initial user account (if it doesn't exist)
+createInitialUser();
 
 const app = express();
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -10,6 +10,7 @@ const {
   ABLY_API_KEY_CUSTOMERS,
   ABLY_API_KEY_RIDERS,
   HASHING_SECRET,
+  USER_TYPE_ADMIN,
 } = require('./common');
 
 const {
@@ -19,9 +20,13 @@ const {
   getGoogleMaps,
   getMapbox,
   getAbly,
+  createUser,
 } = require('./Handlers');
 
-const { authorizeMiddleware } = require('./auth');
+const {
+  authorizeMiddleware,
+  userIsOfTypeMiddleware,
+} = require('./auth');
 
 const SECRET_NAMES = [
   ABLY_API_KEY_RIDERS,
@@ -60,6 +65,8 @@ app.delete('/orders/:orderId', deleteOrder);
 app.get('/googleMaps', getGoogleMaps);
 app.get('/mapbox', getMapbox);
 app.get('/ably', getAbly);
+
+app.post('/admin/user', createUser, userIsOfTypeMiddleware(USER_TYPE_ADMIN));
 
 // Our custom error handler, which must be defined here, after other app.use() and routes calls.
 app.use(errorHandlingMiddleware);

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,7 +3,7 @@
   "description": "Cloud Functions for Firebase",
   "scripts": {
     "lint": "eslint .",
-    "serve": "firebase emulators:start --only functions",
+    "serve": "firebase emulators:start --only functions,firestore",
     "shell": "firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",


### PR DESCRIPTION
This PR adds hashing/salting to passwords, and also adds a method of generating new accounts since these can't easily be inserted into the database now.

The PR adds a new secret, `INITIAL_USER_PASSWORD`, which is used to create a new user named 'admin' on initialization. This user can then be used to create new users by sending a POST request to /admin/user with the body `{"username": "user", "password": "pass", "type": "rider"}`


Resolves #6 